### PR TITLE
fix: prefix AJAX action with spotmap_ namespace

### DIFF
--- a/includes/class-spotmap.php
+++ b/includes/class-spotmap.php
@@ -104,8 +104,8 @@ class Spotmap{
 		$this->loader->add_action( 'wp_enqueue_scripts', $spotmap_public, 'enqueue_styles');
 		$this->loader->add_action( 'wp_enqueue_scripts', $spotmap_public, 'enqueue_scripts');
 		$this->loader->add_action( 'enqueue_block_editor_assets', $spotmap_public, 'enqueue_block_editor_assets');
-		$this->loader->add_action( 'wp_ajax_get_positions', $spotmap_public, 'get_positions');
-		$this->loader->add_action( 'wp_ajax_nopriv_get_positions', $spotmap_public, 'get_positions');
+		$this->loader->add_action( 'wp_ajax_spotmap_get_positions', $spotmap_public, 'get_positions');
+		$this->loader->add_action( 'wp_ajax_nopriv_spotmap_get_positions', $spotmap_public, 'get_positions');
 	}
 	/**
 	 * Run the loader to execute all of the hooks with WordPress.

--- a/src/map-engine/Spotmap.ts
+++ b/src/map-engine/Spotmap.ts
@@ -235,7 +235,7 @@ export class Spotmap {
 
         // Fetch and render data
         const body: AjaxRequestBody = {
-            action: 'get_positions',
+            action: 'spotmap_get_positions',
             select: '*',
             feeds: this.options.feeds ?? '',
             'date-range': this.options.dateRange,

--- a/src/map-engine/TableRenderer.ts
+++ b/src/map-engine/TableRenderer.ts
@@ -209,7 +209,7 @@ export class TableRenderer {
 
     private buildRequestBody(): AjaxRequestBody {
         return {
-            action: 'get_positions',
+            action: 'spotmap_get_positions',
             feeds: this.options.feeds ?? '',
             'date-range': this.options.dateRange,
             date: this.options.date,


### PR DESCRIPTION
Rename wp_ajax_get_positions to wp_ajax_spotmap_get_positions to avoid collisions with other plugins and follow WP naming conventions.

https://claude.ai/code/session_01VwBw3gjzVsEKjqG3ZwC6GQ