### PR TITLE
fix(post-location): fix map rendering and marker on new posts

### DIFF
--- a/public/class-spotmap-public.php
+++ b/public/class-spotmap-public.php
@@ -92,7 +92,15 @@ class Spotmap_Public{
 			true
 		);
 		$this->localize_js_script( 'spotmap-handler' );
-		$this->enqueue_styles();
+		// Always load the map CSS in the editor — should_enqueue() would skip it
+		// for new posts that don't yet have a Spotmap block, but the post-location
+		// sidebar map picker needs Leaflet CSS on every post.
+		wp_enqueue_style(
+			'spotmap-map',
+			plugin_dir_url( dirname( __FILE__ ) ) . 'build/spotmap-map.css',
+			[],
+			$map_asset['version']
+		);
 		$this->localize_js_script( 'spotmap-spotmap-editor-script' );
 		$this->localize_js_script( 'spotmap-spotmessages-editor-script' );
 

--- a/src/post-location/index.js
+++ b/src/post-location/index.js
@@ -12,6 +12,20 @@ import {
 
 const LS_KEY = 'spotmap_post_location_last_center';
 
+function makePostIcon( color = 'blue' ) {
+    const L = window.L;
+    const cfg = window.spotmapjsobj?.marker?.POST ?? {
+        iconShape: 'marker',
+        icon: 'thumbtack',
+    };
+    return L.BeautifyIcon.icon( {
+        iconShape: cfg.iconShape,
+        icon: cfg.icon,
+        textColor: color,
+        borderColor: color,
+    } );
+}
+
 function getLastCenter() {
     try {
         const stored = localStorage.getItem( LS_KEY );
@@ -69,9 +83,10 @@ const PostLocationMap = forwardRef( function PostLocationMap(
         } ).addTo( map );
 
         if ( lat && lng ) {
-            const marker = L.marker( [ lat, lng ], { draggable: true } ).addTo(
-                map
-            );
+            const marker = L.marker( [ lat, lng ], {
+                draggable: true,
+                icon: makePostIcon(),
+            } ).addTo( map );
             marker.on( 'dragend', () => {
                 const pos = marker.getLatLng();
                 saveLastCenter( pos.lat, pos.lng, map.getZoom() );
@@ -90,6 +105,7 @@ const PostLocationMap = forwardRef( function PostLocationMap(
             } else {
                 const marker = L.marker( [ clickLat, clickLng ], {
                     draggable: true,
+                    icon: makePostIcon(),
                 } ).addTo( map );
                 marker.on( 'dragend', () => {
                     const pos = marker.getLatLng();
@@ -136,9 +152,10 @@ const PostLocationMap = forwardRef( function PostLocationMap(
         } else if ( markerRef.current ) {
             markerRef.current.setLatLng( [ lat, lng ] );
         } else {
-            const marker = L.marker( [ lat, lng ], { draggable: true } ).addTo(
-                map
-            );
+            const marker = L.marker( [ lat, lng ], {
+                draggable: true,
+                icon: makePostIcon(),
+            } ).addTo( map );
             marker.on( 'dragend', () => {
                 const pos = marker.getLatLng();
                 saveLastCenter( pos.lat, pos.lng, map.getZoom() );
@@ -155,6 +172,8 @@ const PostLocationMap = forwardRef( function PostLocationMap(
                 height: '240px',
                 width: '100%',
                 marginBottom: '8px',
+                overflow: 'hidden',
+                position: 'relative',
             } }
         />
     );


### PR DESCRIPTION
## Summary

- **Leaflet CSS not loaded on new posts** — `enqueue_block_editor_assets()` called `enqueue_styles()` which bails early via `should_enqueue()` when the post has no Spotmap block yet. Replaced the call with a direct `wp_enqueue_style()` so the CSS is always loaded in the editor.
- **Tiles overflowing the map container** — added `overflow: hidden` and `position: relative` to the map container div (belt-and-suspenders, since Leaflet CSS also sets this on `.leaflet-container`). Without CSS loaded, tiles bled outside the div and sat on top of the Clear location button, causing apparent click misses and tiny coordinate shifts from accidental map clicks.
- **BeautifyIcon marker** — replaced the default Leaflet PNG marker (broken URL in editor context) with `L.BeautifyIcon` using the `POST` type config from `spotmapjsobj.marker` (thumbtack icon by default, respects admin customisation).

## Test plan

- [ ] Open a brand-new post in the block editor — map renders correctly, tiles stay inside the container, attribution is visible
- [ ] Click on the map to set a location — BeautifyIcon thumbtack marker appears
- [ ] Drag the marker — coordinates update
- [ ] Click **Clear location** — marker disappears, coordinates cleared
- [ ] Open an existing post with a Spotmap block — no regression in map or block behaviour