### PR TITLE
fix(map): prevent theme CSS from collapsing circle-marker SVG to 0×0

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,6 +4,15 @@
     font-size: 12px;
 }
 
+/* Prevent themes that set svg { max-width: 100%; height: auto; } from
+   collapsing Leaflet renderer SVGs to 0×0. The pane <div> is position:absolute
+   with no explicit width, so 100% resolves to 0, wiping out the SVG dimensions
+   that Leaflet sets via attributes. */
+.leaflet-pane > svg {
+    max-width: none !important;
+    height: auto !important;
+}
+
 /* map toggle work with twenty twenty template */
 
 /* .leaflet-control-layers-list {

--- a/src/map-engine/Spotmap.ts
+++ b/src/map-engine/Spotmap.ts
@@ -221,7 +221,12 @@ export class Spotmap {
             this.layers,
             dbg
         );
-        const canvasRenderer = L.svg( { pane: 'markerPane' } );
+        // Use a dedicated pane (z-index 450, above overlayPane 400) so that
+        // circle-dot markers render above polylines. Avoids theme CSS targeting
+        // .leaflet-marker-pane which can set the SVG to 0×0.
+        this.map.createPane( 'spotmapCirclePane' );
+        ( this.map.getPane( 'spotmapCirclePane' ) as HTMLElement ).style.zIndex = '450';
+        const canvasRenderer = L.svg( { pane: 'spotmapCirclePane' } );
         this.markerManager = new MarkerManager(
             this.map,
             this.layers,

--- a/src/map-engine/__tests__/Spotmap.test.ts
+++ b/src/map-engine/__tests__/Spotmap.test.ts
@@ -57,6 +57,10 @@ let capturedGpxEmitter: ReturnType< typeof createEventEmitter > | null;
 function buildLeafletMock() {
     capturedGpxEmitter = null;
 
+    const mockPane = Object.assign( document.createElement( 'div' ), {
+        style: { zIndex: '' },
+    } );
+
     const mockMap = {
         scrollWheelZoom: { enable: jest.fn(), disable: jest.fn() },
         once: jest.fn(),
@@ -69,6 +73,8 @@ function buildLeafletMock() {
         invalidateSize: jest.fn(),
         removeLayer: jest.fn(),
         attributionControl: { setPrefix: jest.fn() },
+        createPane: jest.fn(),
+        getPane: jest.fn().mockReturnValue( mockPane ),
     };
 
     const mockLayerControl = {


### PR DESCRIPTION
## Summary

- Some themes apply `svg { max-width: 100%; height: auto; }` globally. Leaflet's renderer pane `<div>` is `position: absolute` with no explicit width, so `100%` resolves to 0 — silently wiping out the `width`/`height` attributes Leaflet sets on the SVG. Circle markers (`L.circleMarker`) get clipped to nothing while polylines remain visible because they overflow their clipped SVG differently.
- Fix: add `.leaflet-pane > svg { max-width: none !important; }` to neutralise the theme override.
- Also moves the circle-dot renderer from `markerPane` to a dedicated `spotmapCirclePane` (z-index 450, between overlayPane 400 and markerPane 600), so circle markers render above polylines and are isolated from any pane-specific CSS targeting.

## Diagnosis

DevTools on the affected page showed:
- SVG `width` / `height` **attributes** correct (`781`, `600`) — Leaflet JS was fine
- `getBoundingClientRect()` returned `width: 0, height: 0` — CSS was overriding to zero
- Map container itself had correct dimensions (651×500) — not a hidden-container issue

## Test plan

- [ ] Build (`npm run build`) and install on a site using a theme with `svg { max-width: 100%; height: auto; }` (e.g. Twenty Twenty-One) — circle-dot track markers should now appear
- [ ] Verify polylines still render correctly
- [ ] Verify circle markers appear above polylines (z-index ordering)
- [ ] Check no regression on local dev env where the issue was not reproducible

🤖 Generated with [Claude Code](https://claude.com/claude-code)