### PR TITLE
fix(garmin): support regional MapShare endpoints and warn on full URL input

### DIFF
--- a/includes/class-spotmap-api-crawler.php
+++ b/includes/class-spotmap-api-crawler.php
@@ -167,7 +167,7 @@ class Spotmap_Api_Crawler
                                : $chunk_secs;
                 $chunk_start = max((int) $cursor['at'] - $advance, $garmin_epoch);
                 $chunk_end   = (int) $cursor['at'];
-                $url         = 'https://share.garmin.com/Feed/Share/' . rawurlencode($mapshare_address)
+                $url         = $this->garmin_feed_share_base($mapshare_address)
                              . '?d1=' . gmdate('Y-m-d\TH:i\Z', $chunk_start)
                              . '&d2=' . gmdate('Y-m-d\TH:i\Z', $chunk_end);
 
@@ -212,7 +212,7 @@ class Spotmap_Api_Crawler
                 // Also check for live points that arrived since the first chunk seeded the DB.
                 // Skip on the very first tick ($db_is_empty) because last_time is 0.
                 if (! $db_is_empty) {
-                    $inc_url  = 'https://share.garmin.com/Feed/Share/' . rawurlencode($mapshare_address)
+                    $inc_url  = $this->garmin_feed_share_base($mapshare_address)
                               . '?d1=' . gmdate('Y-m-d\TH:i\Z', $last_time + 1);
                     $this->garmin_log($feed_name, 'incremental_during_backfill', [
                         'd1' => gmdate('Y-m-d H:i:s', $last_time + 1),
@@ -231,7 +231,7 @@ class Spotmap_Api_Crawler
         }
 
         // ── Incremental mode ────────────────────────────────────────────────
-        $url = 'https://share.garmin.com/Feed/Share/' . rawurlencode($mapshare_address)
+        $url = $this->garmin_feed_share_base($mapshare_address)
              . '?d1=' . gmdate('Y-m-d\TH:i\Z', $last_time + 1);
         $this->garmin_log($feed_name, 'incremental_fetch', [
             'd1' => gmdate('Y-m-d H:i:s', $last_time + 1),
@@ -461,6 +461,18 @@ class Spotmap_Api_Crawler
         ]);
 
         return $inserted;
+    }
+
+    private function garmin_feed_share_base(string $mapshare_address): string
+    {
+        $parsed = parse_url($mapshare_address);
+        if (isset($parsed['host'])) {
+            $scheme   = $parsed['scheme'] ?? 'https';
+            $host     = $parsed['host'];
+            $username = ltrim($parsed['path'] ?? '', '/');
+            return $scheme . '://' . $host . '/Feed/Share/' . rawurlencode($username);
+        }
+        return 'https://share.garmin.com/Feed/Share/' . rawurlencode($mapshare_address);
     }
 
     /**

--- a/includes/class-spotmap-providers.php
+++ b/includes/class-spotmap-providers.php
@@ -70,7 +70,7 @@ class Spotmap_Providers
                             'type'        => 'text',
                             'label'       => 'MapShare Address',
                             'required'    => true,
-                            'description' => 'Your MapShare username (the part after share.garmin.com/Feed/Share/).',
+                            'description' => 'Your MapShare username — the last part of your MapShare URL (e.g. "JohnDoe").',
                         ],
                         [
                             'key'         => 'password',

--- a/src/spotmap-admin/components/FeedModal.jsx
+++ b/src/spotmap-admin/components/FeedModal.jsx
@@ -10,6 +10,7 @@ import {
     FlexItem,
     Notice,
 } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 import { arrowLeft, chevronDown, chevronUp } from '@wordpress/icons';
 import { REDACTED, getVictronInstallations } from '../api';
 
@@ -401,36 +402,51 @@ export default function FeedModal( {
 
                     const isClearing =
                         isPasswordField && passwordClearing.has( field.key );
+                    const fieldValue = fields[ field.key ] ?? '';
+                    const looksLikeUrl =
+                        type === 'garmin-inreach' &&
+                        field.key === 'mapshare_address' &&
+                        ( fieldValue.includes( '://' ) ||
+                            fieldValue.startsWith( 'www.' ) );
                     return (
-                        <TextControl
-                            key={ field.key }
-                            label={ field.label }
-                            help={ help }
-                            type={ isPasswordField ? 'password' : 'text' }
-                            value={
-                                isPasswordField &&
-                                fields[ field.key ] === REDACTED
-                                    ? ''
-                                    : fields[ field.key ] ?? ''
-                            }
-                            autoComplete="off"
-                            onChange={ ( val ) => {
-                                if ( isPasswordField ) {
-                                    if ( isClearing ) {
-                                        setField( field.key, val );
-                                    } else {
-                                        setField(
-                                            field.key,
-                                            val === '' ? REDACTED : val
-                                        );
-                                    }
-                                } else {
-                                    setField( field.key, val );
+                        <Fragment key={ field.key }>
+                            <TextControl
+                                label={ field.label }
+                                help={ help }
+                                type={ isPasswordField ? 'password' : 'text' }
+                                value={
+                                    isPasswordField && fieldValue === REDACTED
+                                        ? ''
+                                        : fieldValue
                                 }
-                            } }
-                            __nextHasNoMarginBottom
-                            __next40pxDefaultSize
-                        />
+                                autoComplete="off"
+                                onChange={ ( val ) => {
+                                    if ( isPasswordField ) {
+                                        if ( isClearing ) {
+                                            setField( field.key, val );
+                                        } else {
+                                            setField(
+                                                field.key,
+                                                val === '' ? REDACTED : val
+                                            );
+                                        }
+                                    } else {
+                                        setField( field.key, val );
+                                    }
+                                } }
+                                __nextHasNoMarginBottom
+                                __next40pxDefaultSize
+                            />
+                            { looksLikeUrl && (
+                                <Notice status="warning" isDismissible={ false }>
+                                    Enter only the last part of the URL — e.g.{' '}
+                                    <strong>
+                                        { fieldValue.split( '/' ).filter( Boolean ).pop() ?? 'Username' }
+                                    </strong>{' '}
+                                    — not the full address.
+                                </Notice>
+                            ) }
+                        </Fragment>
                     );
                 } ) }
 


### PR DESCRIPTION
## Summary

- `garmin_feed_share_base()` now handles both bare usernames (`JohnDoe`) and full MapShare page URLs (`https://eur-share.inreach.garmin.com/JohnDoe`), building the correct Feed/Share API endpoint in either case — fixes data fetching for European/regional Garmin accounts
- `FeedModal` shows a warning notice with the extracted username suggestion when the `mapshare_address` field contains a full URL, guiding users to correct their input
- Provider field description updated to clarify only the username is expected

## Test plan

- [ ] Add a Garmin inReach feed with a bare username — verify it fetches from `share.garmin.com/Feed/Share/{username}`
- [ ] Add a feed with a full URL (e.g. `https://eur-share.inreach.garmin.com/User`) — verify the warning notice appears with the extracted username, and fetching hits the correct regional endpoint
- [ ] Edit an existing feed with a bare username — verify no warning is shown