### PR TITLE
feat(editor): raise point limit to 150k for LOD-backed preview

### DIFF
--- a/includes/class-spotmap-database.php
+++ b/includes/class-spotmap-database.php
@@ -7,7 +7,7 @@ class Spotmap_Database
      * Prevents runaway memory use / PHP timeout on large datasets.
      * Callers can pass a lower $filter['limit'] to request fewer rows.
      */
-    public const MAX_POINTS_PER_QUERY = 50000;
+    public const MAX_POINTS_PER_QUERY = 150000;
 
     private const ALLOWED_COLUMNS = [
             'id', 'type', 'time', 'latitude', 'longitude', 'altitude',

--- a/src/spotmap/edit.jsx
+++ b/src/spotmap/edit.jsx
@@ -32,6 +32,8 @@ import GpxManagerModal from './components/GpxManagerModal';
 import { COLORS } from './constants';
 import { SATELLITE_ICON } from './icons';
 
+const EDITOR_POINT_LIMIT = 150000;
+
 const DEFAULT_FEED_STYLE = {
     color: 'blue',
     splitLines: 8,
@@ -262,9 +264,9 @@ export default function Edit( { attributes, setAttributes } ) {
                 .filter( Boolean );
             const numColors = adminColors.length || 1;
 
-            // If the DB already holds more than 10 000 points, default to no feeds
+            // If the DB already holds more than 150 000 points, default to no feeds
             // so the editor doesn't immediately try to render a huge dataset.
-            const enabledNames = totalPoints > 50000 ? [] : feedNames;
+            const enabledNames = totalPoints > EDITOR_POINT_LIMIT ? [] : feedNames;
             const defaultFeedObjects = enabledNames.map( ( name, i ) => ( {
                 name,
                 ...DEFAULT_FEED_STYLE,
@@ -312,7 +314,7 @@ export default function Edit( { attributes, setAttributes } ) {
         }
 
         // Skip map init while point count is still loading, or if selected feeds exceed the editor threshold.
-        if ( selectedPoints === null || selectedPoints > 50000 ) {
+        if ( selectedPoints === null || selectedPoints > EDITOR_POINT_LIMIT ) {
             return;
         }
 
@@ -852,7 +854,7 @@ export default function Edit( { attributes, setAttributes } ) {
                     },
                 } ) }
             >
-                { selectedPoints !== null && selectedPoints > 50000 ? (
+                { selectedPoints !== null && selectedPoints > EDITOR_POINT_LIMIT ? (
                     <div
                         style={ {
                             height: '100%',
@@ -873,7 +875,7 @@ export default function Edit( { attributes, setAttributes } ) {
                                 'Map preview disabled — selected feeds contain'
                             ) }{ ' ' }
                             { selectedPoints.toLocaleString() }{ ' ' }
-                            { __( 'points (limit: 50,000).' ) }
+                            { __( 'points (limit: 150,000).' ) }
                         </strong>
                         <span>
                             { __(


### PR DESCRIPTION
## Summary

- Introduces `EDITOR_POINT_LIMIT = 150000` constant in `edit.jsx` as single source of truth (replaces three hardcoded `50000` values)
- Raises `MAX_POINTS_PER_QUERY` in `class-spotmap-database.php` from 50 000 to 150 000 to match

## Why

The LOD manager (screen-space RDP simplification, #82) keeps the editor map preview smooth even with large datasets, making the old conservative 50k cap unnecessarily restrictive.

## Test plan

- [ ] Open block editor with a feed containing 25k–150k points — map preview should render without the "preview disabled" banner
- [ ] Verify feeds exceeding 150k still show the banner and don't attempt to render