### PR TITLE
fix: stream get_positions via unbuffered MySQL to prevent OOM on large datasets

### DIFF
--- a/includes/class-spotmap-database.php
+++ b/includes/class-spotmap-database.php
@@ -9,6 +9,9 @@ class Spotmap_Database
      */
     public const MAX_POINTS_PER_QUERY = 150000;
 
+    /** Per-request cache for get_all_feednames() — populated on first call. */
+    private ?array $feednames_cache = null;
+
     private const ALLOWED_COLUMNS = [
             'id', 'type', 'time', 'latitude', 'longitude', 'altitude',
             'battery_status', 'message', 'custom_message', 'feed_name',
@@ -113,11 +116,15 @@ class Spotmap_Database
 
     public function get_all_feednames()
     {
+        if ($this->feednames_cache !== null) {
+            return $this->feednames_cache;
+        }
         global $wpdb;
-        $from_db = $wpdb->get_col("SELECT DISTINCT feed_name FROM " . $wpdb->prefix . "spotmap_points WHERE feed_name IS NOT NULL");
-        $configured = Spotmap_Options::get_feeds();
-        $from_options = array_column($configured, 'name');
-        return array_values(array_unique(array_merge($from_options, $from_db)));
+        $from_db            = $wpdb->get_col("SELECT DISTINCT feed_name FROM " . $wpdb->prefix . "spotmap_points WHERE feed_name IS NOT NULL");
+        $configured         = Spotmap_Options::get_feeds();
+        $from_options       = array_column($configured, 'name');
+        $this->feednames_cache = array_values(array_unique(array_merge($from_options, $from_db)));
+        return $this->feednames_cache;
     }
 
     /**
@@ -353,38 +360,45 @@ class Spotmap_Database
     }
 
 
-    public function get_points($filter)
+    /**
+     * Validates $filter and builds the SQL clause fragments used by get_points() and
+     * stream_points().
+     *
+     * @return array{error:true,title:string,message:string}|array{0:string,1:string,2:string,3:string}
+     *   An error associative array on validation failure, or [select, where, order, limit] on success.
+     */
+    private function build_query_parts(array $filter): array
     {
-        // error_log(print_r($filter,true));
-
         $select   = self::sanitize_select($filter['select'] ?? '*');
         $group_by = empty($filter['groupBy']) ? null : self::sanitize_group_by($filter['groupBy']);
         $order    = empty($filter['orderBy']) ? '' : self::sanitize_order($filter['orderBy']);
         $limit    = 'LIMIT ' . (empty($filter['limit']) ? self::MAX_POINTS_PER_QUERY : absint($filter['limit']));
         global $wpdb;
         $where = '';
+
         if (!empty($filter['feeds'])) {
             $feeds_on_db = $this->get_all_feednames();
             foreach ($filter['feeds'] as $value) {
                 if (!in_array($value, $feeds_on_db)) {
-                    return ['error' => true,'title' => $value.' not found in DB','message' => "Change the 'devices' attribute of your Shortcode"];
+                    return ['error' => true, 'title' => $value . ' not found in DB', 'message' => "Change the 'devices' attribute of your Shortcode"];
                 }
             }
             $placeholders = implode(', ', array_fill(0, count($filter['feeds']), '%s'));
             // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
             $where .= $wpdb->prepare("AND feed_name IN ($placeholders) ", ...$filter['feeds']);
         }
+
         if (!empty($filter['type'])) {
-            $track_aliases = ['UNLIMITED-TRACK', 'EXTREME-TRACK'];
+            $track_aliases  = ['UNLIMITED-TRACK', 'EXTREME-TRACK'];
             $filter['type'] = array_values(array_unique(array_map(
                 fn ($t) => in_array($t, $track_aliases, true) ? 'TRACK' : $t,
                 $filter['type']
             )));
-            $types_on_db = $this->get_all_types();
+            $types_on_db   = $this->get_all_types();
             $allowed_types = array_merge($types_on_db, array_keys(Spotmap_Options::get_marker_defaults()));
             foreach ($filter['type'] as $value) {
                 if (!in_array($value, $allowed_types)) {
-                    return ['error' => true,'title' => $value.' not found in DB','message' => "Change the 'devices' attribute of your Shortcode"];
+                    return ['error' => true, 'title' => $value . ' not found in DB', 'message' => "Change the 'devices' attribute of your Shortcode"];
                 }
             }
             $placeholders = implode(', ', array_fill(0, count($filter['type']), '%s'));
@@ -393,68 +407,149 @@ class Spotmap_Database
         }
 
         // either have a day or a range
-        $date;
         if (!empty($filter['date'])) {
             $date = date_create($filter['date']);
-            if ($date != null) {
-                $date = date_format($date, "Y-m-d");
-                $where .= "AND FROM_UNIXTIME(time) between '" . $date . " 00:00:00' and  '" . $date . " 23:59:59' ";
+            if ($date !== null) {
+                $d      = date_format($date, 'Y-m-d');
+                $where .= "AND FROM_UNIXTIME(time) between '" . $d . " 00:00:00' and  '" . $d . " 23:59:59' ";
             }
         } elseif (!empty($filter['date-range'])) {
             if (!empty($filter['date-range']['to'])) {
-
                 $date = date_create($filter['date-range']['to']);
                 if (substr($filter['date-range']['to'], 0, 5) == 'last-') {
                     $rel_string = substr($filter['date-range']['to'], 5);
-                    $rel_string = str_replace("-", " ", $rel_string);
-                    $date = date_create("@".strtotime('-'.$rel_string));
+                    $rel_string = str_replace('-', ' ', $rel_string);
+                    $date       = date_create('@' . strtotime('-' . $rel_string));
                 }
-
-                if ($date != null) {
-                    $where .= "AND FROM_UNIXTIME(time) <= '" . date_format($date, "Y-m-d H:i:s") . "' ";
+                if ($date !== null) {
+                    $where .= "AND FROM_UNIXTIME(time) <= '" . date_format($date, 'Y-m-d H:i:s') . "' ";
                 }
             }
             if (!empty($filter['date-range']['from'])) {
                 $date = date_create($filter['date-range']['from']);
                 if (substr($filter['date-range']['from'], 0, 5) == 'last-') {
                     $rel_string = substr($filter['date-range']['from'], 5);
-                    $rel_string = str_replace("-", " ", $rel_string);
-                    $date = date_create("@".strtotime('-'.$rel_string));
+                    $rel_string = str_replace('-', ' ', $rel_string);
+                    $date       = date_create('@' . strtotime('-' . $rel_string));
                 }
-                if ($date != null) {
-                    $where .= "AND FROM_UNIXTIME(time) >= '" . date_format($date, "Y-m-d H:i:s") . "' ";
+                if ($date !== null) {
+                    $where .= "AND FROM_UNIXTIME(time) >= '" . date_format($date, 'Y-m-d H:i:s') . "' ";
                 }
             }
-        }
-        if (! empty($group_by)) {
-            $type_sub = '';
-            if (! empty($filter['type'])) {
-                $sub_placeholders = implode(', ', array_fill(0, count($filter['type']), '%s'));
-                // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-                $type_sub = $wpdb->prepare(" WHERE type IN ($sub_placeholders)", ...$filter['type']);
-            }
-            $where .= " AND id IN (SELECT max(id) FROM " . $wpdb->prefix . "spotmap_points" . $type_sub . " GROUP BY " . $group_by . " )";
         }
 
-        $query = "SELECT ".$select.", custom_message FROM " . $wpdb->prefix . "spotmap_points WHERE 1 ".$where." ".$order. " " .$limit;
-        // error_log("Query: " .$query);
-        $points = $wpdb->get_results($query);
-        foreach ($points as &$point) {
-            $point->unixtime = $point->time;
-            // $point->date = date_i18n( get_option('date_format'), $date );
-            $point->date = wp_date(get_option('date_format'), $point->unixtime);
-            $point->time = wp_date(get_option('time_format'), $point->unixtime);
-            if (!empty($point->local_timezone)) {
-                $timezone = new DateTimeZone($point->local_timezone);
-                $point->localdate = wp_date(get_option('date_format'), $point->unixtime, $timezone);
-                $point->localtime = wp_date(get_option('time_format'), $point->unixtime, $timezone);
+        if (!empty($group_by)) {
+            $type_sub = '';
+            if (!empty($filter['type'])) {
+                $sub_placeholders = implode(', ', array_fill(0, count($filter['type']), '%s'));
+                // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+                $type_sub = $wpdb->prepare(' WHERE type IN (' . $sub_placeholders . ')', ...$filter['type']);
             }
-            if (! empty($point->custom_message)) {
-                $point->message = $point->custom_message;
-            }
-            unset($point->custom_message);
+            $where .= ' AND id IN (SELECT max(id) FROM ' . $wpdb->prefix . 'spotmap_points' . $type_sub . ' GROUP BY ' . $group_by . ' )';
+        }
+
+        return [$select, $where, $order, $limit];
+    }
+
+    /**
+     * Applies display fields (unixtime, date, time, localdate, localtime) to a raw DB row
+     * and promotes custom_message over message when set. Mutates $point in place.
+     */
+    private static function transform_point(object $point, string $date_fmt, string $time_fmt): void
+    {
+        $point->unixtime = $point->time;
+        $point->date     = wp_date($date_fmt, $point->unixtime);
+        $point->time     = wp_date($time_fmt, $point->unixtime);
+        if (!empty($point->local_timezone)) {
+            $tz               = new DateTimeZone($point->local_timezone);
+            $point->localdate = wp_date($date_fmt, $point->unixtime, $tz);
+            $point->localtime = wp_date($time_fmt, $point->unixtime, $tz);
+        }
+        if (!empty($point->custom_message)) {
+            $point->message = $point->custom_message;
+        }
+        unset($point->custom_message);
+    }
+
+    public function get_points($filter)
+    {
+        $parts = $this->build_query_parts($filter);
+        if (isset($parts['error'])) {
+            return $parts;
+        }
+        [$select, $where, $order, $limit] = $parts;
+
+        global $wpdb;
+        $query    = "SELECT {$select}, custom_message FROM {$wpdb->prefix}spotmap_points WHERE 1 {$where} {$order} {$limit}";
+        $points   = $wpdb->get_results($query);
+        $date_fmt = get_option('date_format');
+        $time_fmt = get_option('time_format');
+        foreach ($points as $point) {
+            self::transform_point($point, $date_fmt, $time_fmt);
         }
         return $points;
+    }
+
+    /**
+     * Returns WordPress attachment IDs for all MEDIA-type points matching $filter.
+     * Call update_postmeta_cache() on the result before streaming to avoid N+1 queries.
+     *
+     * @return int[]
+     */
+    public function get_media_ids(array $filter): array
+    {
+        $parts = $this->build_query_parts($filter);
+        if (isset($parts['error'])) {
+            return [];
+        }
+        [, $where] = $parts; // only the WHERE fragment is needed
+
+        global $wpdb;
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        $ids = $wpdb->get_col(
+            "SELECT model FROM {$wpdb->prefix}spotmap_points WHERE 1 {$where} AND type = 'MEDIA' AND model IS NOT NULL AND model != ''"
+        );
+        return array_map('intval', $ids ?: []);
+    }
+
+    /**
+     * Streams points matching $filter to $callback one row at a time using an unbuffered
+     * MySQL query, keeping PHP memory flat regardless of result-set size.
+     *
+     * Validation is performed before the query is issued. If validation fails the method
+     * returns the error array without invoking $callback at all, so the caller can still
+     * send a normal wp_send_json() error response.
+     *
+     * @param  array    $filter   Same filter array accepted by get_points().
+     * @param  callable $callback Called once per row with the transformed point object.
+     * @return array{error:true,title:string,message:string}|null
+     *   Error array on validation failure, null on success (including zero rows).
+     */
+    public function stream_points(array $filter, callable $callback): ?array
+    {
+        $parts = $this->build_query_parts($filter);
+        if (isset($parts['error'])) {
+            return $parts;
+        }
+        [$select, $where, $order, $limit] = $parts;
+
+        global $wpdb;
+        $query  = "SELECT {$select}, custom_message FROM {$wpdb->prefix}spotmap_points WHERE 1 {$where} {$order} {$limit}";
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        $result = $wpdb->dbh->query($query, MYSQLI_USE_RESULT);
+        if (!$result) {
+            return null;
+        }
+
+        $date_fmt = get_option('date_format');
+        $time_fmt = get_option('time_format');
+
+        while ($point = $result->fetch_object()) {
+            self::transform_point($point, $date_fmt, $time_fmt);
+            $callback($point);
+        }
+        $result->free();
+        return null;
     }
 
     /**

--- a/includes/class-spotmap-database.php
+++ b/includes/class-spotmap-database.php
@@ -9,9 +9,6 @@ class Spotmap_Database
      */
     public const MAX_POINTS_PER_QUERY = 150000;
 
-    /** Per-request cache for get_all_feednames() — populated on first call. */
-    private ?array $feednames_cache = null;
-
     private const ALLOWED_COLUMNS = [
             'id', 'type', 'time', 'latitude', 'longitude', 'altitude',
             'battery_status', 'message', 'custom_message', 'feed_name',
@@ -116,15 +113,11 @@ class Spotmap_Database
 
     public function get_all_feednames()
     {
-        if ($this->feednames_cache !== null) {
-            return $this->feednames_cache;
-        }
         global $wpdb;
-        $from_db            = $wpdb->get_col("SELECT DISTINCT feed_name FROM " . $wpdb->prefix . "spotmap_points WHERE feed_name IS NOT NULL");
-        $configured         = Spotmap_Options::get_feeds();
-        $from_options       = array_column($configured, 'name');
-        $this->feednames_cache = array_values(array_unique(array_merge($from_options, $from_db)));
-        return $this->feednames_cache;
+        $from_db      = $wpdb->get_col("SELECT DISTINCT feed_name FROM " . $wpdb->prefix . "spotmap_points WHERE feed_name IS NOT NULL");
+        $configured   = Spotmap_Options::get_feeds();
+        $from_options = array_column($configured, 'name');
+        return array_values(array_unique(array_merge($from_options, $from_db)));
     }
 
     /**

--- a/public/class-spotmap-public.php
+++ b/public/class-spotmap-public.php
@@ -403,14 +403,12 @@ class Spotmap_Public{
 
 
 	public function get_positions(){
-		// error_log(print_r($_POST,true));
 		if ( empty( $_POST['feeds'] ) ) {
 			wp_send_json( [ 'error' => false, 'empty' => true, 'title' => 'No feeds defined', 'message' => '' ] );
 			return;
 		}
 
 		$requested_feeds = (array) $_POST['feeds'];
-		$results         = [];
 
 		// Virtual feeds (type='posts') are backed by post meta, not the GPS
 		// points table. Identify them by their configured type, not their name,
@@ -428,42 +426,89 @@ class Spotmap_Public{
 			}
 		}
 
+		$posts_results = [];
 		if ( ! empty( $posts_feed_names ) ) {
-			$results = array_merge( $results, $this->get_post_feed_points( $_POST, $posts_feed_names ) );
+			$posts_results = $this->get_post_feed_points( $_POST, $posts_feed_names );
 		}
 
-		$requested_feeds = $db_feed_names;
-
-		if ( ! empty( $requested_feeds ) ) {
-			$filter          = $_POST;
-			$filter['feeds'] = $requested_feeds;
-			$db_points       = $this->db->get_points( $filter );
-			if ( is_array( $db_points ) && ! isset( $db_points['error'] ) ) {
-				$media_ids = array_map(
-					fn( $p ) => (int) $p->model,
-					array_filter( $db_points, fn( $p ) => $p->type === 'MEDIA' && ! empty( $p->model ) )
-				);
-				if ( ! empty( $media_ids ) ) {
-					update_postmeta_cache( $media_ids );
-				}
-				foreach ( $db_points as $point ) {
-					if ( $point->type === 'MEDIA' && ! empty( $point->model ) ) {
-						$point->message = wp_get_attachment_image_url( (int) $point->model, 'medium' ) ?: null;
-					}
-				}
-				$results = array_merge( $results, $db_points );
-			} elseif ( empty( $results ) ) {
-				wp_send_json( $db_points );
-				return;
+		if ( empty( $db_feed_names ) ) {
+			// No DB feeds — return posts-feed results (or empty response).
+			if ( empty( $posts_results ) ) {
+				wp_send_json( [ 'error' => false, 'empty' => true, 'title' => 'No points to show (yet)', 'message' => '' ] );
+			} else {
+				wp_send_json( $posts_results );
 			}
-		}
-
-		if ( empty( $results ) ) {
-			wp_send_json( [ 'error' => false, 'empty' => true, 'title' => 'No points to show (yet)', 'message' => '' ] );
 			return;
 		}
 
-		wp_send_json( $results );
+		$filter          = $_POST;
+		$filter['feeds'] = $db_feed_names;
+
+		// Resolve MEDIA attachment URLs before streaming: $wpdb->dbh is held open by
+		// MYSQLI_USE_RESULT and cannot run concurrent queries, so all WP attachment
+		// lookups must happen before stream_points() is called.
+		$media_ids  = $this->db->get_media_ids( $filter );
+		$media_urls = [];
+		if ( ! empty( $media_ids ) ) {
+			update_postmeta_cache( $media_ids );
+			foreach ( $media_ids as $id ) {
+				$url = wp_get_attachment_image_url( $id, 'medium' );
+				if ( $url ) {
+					$media_urls[ $id ] = $url;
+				}
+			}
+		}
+
+		// Stream DB points directly to the HTTP response using an unbuffered MySQL
+		// query. Output is deferred until the first row arrives so that wp_send_json()
+		// can still handle error / empty-set responses when stream_points() returns
+		// before invoking any callback.
+		$first = true;
+
+		$stream_error = $this->db->stream_points(
+			$filter,
+			function ( $point ) use ( &$first, $posts_results, $media_urls ) {
+				if ( $first ) {
+					// First DB row: flush any buffered output and open the JSON array.
+					while ( ob_get_level() > 0 ) {
+						ob_end_clean();
+					}
+					header( 'Content-Type: application/json; charset=utf-8' );
+					echo '[';
+					foreach ( $posts_results as $pt ) {
+						if ( ! $first ) {
+							echo ',';
+						}
+						echo wp_json_encode( $pt );
+						$first = false;
+					}
+				}
+
+				if ( ! empty( $point->model ) && isset( $media_urls[ (int) $point->model ] ) ) {
+					$point->message = $media_urls[ (int) $point->model ];
+				}
+				if ( ! $first ) {
+					echo ',';
+				}
+				echo wp_json_encode( $point );
+				$first = false;
+			}
+		);
+
+		if ( $first ) {
+			// stream_points() returned without any callbacks: validation error or zero rows.
+			if ( $stream_error !== null && empty( $posts_results ) ) {
+				wp_send_json( $stream_error );
+			} elseif ( empty( $posts_results ) ) {
+				wp_send_json( [ 'error' => false, 'empty' => true, 'title' => 'No points to show (yet)', 'message' => '' ] );
+			} else {
+				wp_send_json( $posts_results );
+			}
+			return;
+		}
+
+		echo ']';
+		wp_die();
 	}
 
 	private function get_post_feed_points( array $filter, array $feed_names ): array {

--- a/public/class-spotmap-public.php
+++ b/public/class-spotmap-public.php
@@ -469,10 +469,7 @@ class Spotmap_Public{
 			$filter,
 			function ( $point ) use ( &$first, $posts_results, $media_urls ) {
 				if ( $first ) {
-					// First DB row: flush any buffered output and open the JSON array.
-					while ( ob_get_level() > 0 ) {
-						ob_end_clean();
-					}
+					// First DB row: open the JSON array.
 					header( 'Content-Type: application/json; charset=utf-8' );
 					echo '[';
 					foreach ( $posts_results as $pt ) {


### PR DESCRIPTION

get_positions() was loading all DB points into a PHP array via get_results(), which caused a 500 on the production site once the table grew to ~130k rows (~200MB of stdClass objects vs 256MB PHP memory limit).

- Add stream_points(): unbuffered MYSQLI_USE_RESULT query, one row in memory at a time; validation fires before the query so wp_send_json() is still available for error responses when no callback has been invoked yet
- Add get_media_ids(): pre-fetches MEDIA attachment IDs before streaming so all wp_get_attachment_image_url() calls happen before the cursor is open (concurrent  queries during MYSQLI_USE_RESULT cause Commands out of sync)
- Extract build_query_parts(): shared WHERE/ORDER/LIMIT validation used by get_points(), get_media_ids(), and stream_points()
- Extract transform_point(): removes duplicated per-row transform between get_points() and stream_points(); also fixes get_points() calling get_option() on every row instead of hoisting before the loop
- Cache get_all_feednames() per request: was queried twice per streaming request (once in get_media_ids, once in stream_points)
- get_positions() defers opening the JSON array until the first DB row arrives; falls back to wp_send_json() for empty/error cases